### PR TITLE
Support different filenames for API contracts

### DIFF
--- a/lib/openapi_contracts/doc.rb
+++ b/lib/openapi_contracts/doc.rb
@@ -5,8 +5,8 @@ module OpenapiContracts
     autoload :Response, 'openapi_contracts/doc/response'
     autoload :Schema,   'openapi_contracts/doc/schema'
 
-    def self.parse(dir)
-      new Parser.call(dir)
+    def self.parse(dir, filename = 'openapi.yaml')
+      new Parser.call(dir, filename)
     end
 
     def initialize(schema)

--- a/lib/openapi_contracts/doc/parser.rb
+++ b/lib/openapi_contracts/doc/parser.rb
@@ -1,14 +1,14 @@
 module OpenapiContracts
   class Doc::Parser
-    def self.call(dir)
-      new(dir).parse('openapi.yaml')
+    def self.call(dir, filename)
+      new(dir).parse(filename)
     end
 
     def initialize(dir)
       @dir = dir
     end
 
-    def parse(path = 'openapi.yaml')
+    def parse(path)
       abs_path = @dir.join(path)
       data = parse_file(abs_path, translate: false)
       data.deep_merge! merge_components

--- a/spec/fixtures/openapi/auth.openapi.yaml
+++ b/spec/fixtures/openapi/auth.openapi.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.2
+info:
+  version: 1.0.0
+  title: Example.com
+  termsOfService: 'https://example.com/terms/'
+  contact:
+    email: contact@example.com
+    url: 'http://example.com/contact'
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+  x-logo:
+    url: 'https://redocly.github.io/openapi-template/logo.png'
+  description: >
+    This is an **example** API to demonstrate features of OpenAPI specification
+tags:
+  - name: Auth
+    description: Authentication
+  - name: User
+    description: Operations about user
+servers:
+  - url: '//api.host.example'
+paths:
+  /health:
+    get:
+      operationId: health_check
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: components/responses/BadRequest.yaml
+        '500':
+          description: Server Error
+  /messages/{id}:
+    $ref: 'paths/message.yaml'
+  /user:
+    $ref: 'paths/user.yaml'

--- a/spec/openapi_contracts/doc_spec.rb
+++ b/spec/openapi_contracts/doc_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe OpenapiContracts::Doc do
   subject(:doc) { described_class.parse(openapi_dir) }
-  
+
   let(:openapi_dir) { FIXTURES_PATH.join('openapi') }
-  
+
   describe '.parse' do
     subject(:defined_doc) { described_class.parse(openapi_dir, 'auth.openapi.yaml') }
 

--- a/spec/openapi_contracts/doc_spec.rb
+++ b/spec/openapi_contracts/doc_spec.rb
@@ -1,10 +1,18 @@
 RSpec.describe OpenapiContracts::Doc do
   subject(:doc) { described_class.parse(openapi_dir) }
-
+  
   let(:openapi_dir) { FIXTURES_PATH.join('openapi') }
-
+  
   describe '.parse' do
-    it { is_expected.to be_a(described_class) }
+    subject(:defined_doc) { described_class.parse(openapi_dir, 'auth.openapi.yaml') }
+
+    it 'parses default document when not defined' do
+      expect(doc).to be_a(described_class)
+    end
+
+    it 'parses correct document when defined' do
+      expect(defined_doc).to be_a(described_class)
+    end
   end
 
   describe '#at_path' do


### PR DESCRIPTION
Hi @mkon, 

what do you think about this feature that I've tried to implement? 

I found your gem useful, but it would be great if it could use different filenames for contracts, instead of just `openapi.yaml` that was previously hard-coded, especially in cases where there are different versions of the API specs (contracts).

For backward-compatibility reasons, I've set the default filename to `openapi.yaml`, but left the possibility for the user to define the name as a second argument.

Hoping to hear your feedback and maybe contribute here.