### PR TITLE
Dynamic path matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,10 @@ Layout/SpaceInsideHashLiteralBraces:
 Lint/AssignmentInCondition:
   Enabled: false
 
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining
+Style/MultilineBlockChain:
+  Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/ConditionalAssignment:

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ it 'responds with 200 and matches the doc' do
 
 The `match_openapi_doc($doc)` method allows passing options as a 2nd argument.
 This allows overriding the default request.path lookup in case this does not find
-the correct response definition in your schema. This is especially important with
-dynamic paths.
+the correct response definition in your schema. This can be usefull when there is
+dynamic parameters in the path and the matcher fails to resolve the request path to
+an endpoint in the openapi specification.
 
 Example:
 
@@ -67,7 +68,9 @@ raise result.errors.merge("/n") unless result.valid?
 
 ### How it works
 
-It uses the `request.path`, `request.method`, `status` and `headers` on the test subject (which must be the response) to find the response schema in the OpenAPI document. Then it does the following checks:
+It uses the `request.path`, `request.method`, `status` and `headers` on the test subject
+(which must be the response) to find the response schema in the OpenAPI document.
+Then it does the following checks:
 
 * The response is documented
 * Required headers are present

--- a/lib/openapi_contracts.rb
+++ b/lib/openapi_contracts.rb
@@ -1,5 +1,6 @@
 require 'active_support'
 require 'active_support/core_ext/array'
+require 'active_support/core_ext/hash'
 require 'active_support/core_ext/class'
 require 'active_support/core_ext/module'
 require 'active_support/core_ext/string'

--- a/lib/openapi_contracts/doc.rb
+++ b/lib/openapi_contracts/doc.rb
@@ -17,8 +17,9 @@ module OpenapiContracts
     def initialize(schema)
       @schema = Schema.new(schema)
       @paths = @schema['paths'].to_h do |path, _|
-        [path, Path.new(@schema.at_pointer(['paths', path]))]
+        [path, Path.new(path, @schema.at_pointer(['paths', path]))]
       end
+      @dynamic_paths = paths.select(&:dynamic?)
     end
 
     # Returns an Enumerator over all paths
@@ -42,7 +43,11 @@ module OpenapiContracts
     end
 
     def with_path(path)
-      @paths[path]
+      if @paths.key?(path)
+        @paths[path]
+      else
+        @dynamic_paths.find { |p| p.matches?(path) }
+      end
     end
   end
 end

--- a/lib/openapi_contracts/doc.rb
+++ b/lib/openapi_contracts/doc.rb
@@ -4,6 +4,7 @@ module OpenapiContracts
     autoload :FileParser, 'openapi_contracts/doc/file_parser'
     autoload :Method,     'openapi_contracts/doc/method'
     autoload :Parser,     'openapi_contracts/doc/parser'
+    autoload :Parameter,  'openapi_contracts/doc/parameter'
     autoload :Path,       'openapi_contracts/doc/path'
     autoload :Response,   'openapi_contracts/doc/response'
     autoload :Schema,     'openapi_contracts/doc/schema'

--- a/lib/openapi_contracts/doc/parameter.rb
+++ b/lib/openapi_contracts/doc/parameter.rb
@@ -1,0 +1,86 @@
+module OpenapiContracts
+  class Doc::Parameter
+    attr_reader :schema
+
+    def initialize(options)
+      @name = options[:name]
+      @in = options[:in]
+      @required = options[:required]
+      @schema = options[:schema]
+    end
+
+    def matches?(value)
+      case schema['type']
+      when 'integer'
+        integer_parameter_matches?(value)
+      when 'number'
+        number_parameter_matches?(value)
+      when 'string'
+        string_parameter_matches?(value)
+      else
+        # Not yet implemented
+        false
+      end
+    end
+
+    private
+
+    def integer_parameter_matches?(value)
+      return false unless /^-?\d+$/.match?(value)
+
+      parsed = value.to_i
+      return false unless minimum_number_matches?(parsed)
+      return false unless maximum_number_matches?(parsed)
+
+      true
+    end
+
+    def number_parameter_matches?(value)
+      return false unless /^-?(\d+\.)?\d+$/.match?(value)
+
+      parsed = value.to_f
+      return false unless minimum_number_matches?(parsed)
+      return false unless maximum_number_matches?(parsed)
+
+      true
+    end
+
+    def minimum_number_matches?(value)
+      if (min = schema['minimum'])
+        if schema['exclusiveMinimum']
+          return false if value <= min
+        elsif value < min
+          return false
+        end
+      end
+      true
+    end
+
+    def maximum_number_matches?(value)
+      if (max = schema['maximum'])
+        if schema['exclusiveMaximum']
+          return false if value >= max
+        elsif value > max
+          return false
+        end
+      end
+      true
+    end
+
+    def string_parameter_matches?(value)
+      if (pat = schema['pattern'])
+        Regexp.new(pat).match?(value)
+      else
+        if (min = schema['minLength']) && (value.length < min)
+          return false
+        end
+
+        if (max = schema['maxLength']) && (value.length > max)
+          return false
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/lib/openapi_contracts/doc/path.rb
+++ b/lib/openapi_contracts/doc/path.rb
@@ -1,6 +1,7 @@
 module OpenapiContracts
   class Doc::Path
-    def initialize(schema)
+    def initialize(path, schema)
+      @path = path
       @schema = schema
 
       @methods = (known_http_methods & @schema.keys).to_h do |method|
@@ -8,8 +9,25 @@ module OpenapiContracts
       end
     end
 
+    def dynamic?
+      @path.include?('{')
+    end
+
+    def matches?(path)
+      @path == path || regexp_path.match(path) do |m|
+        m.named_captures.each do |k, v|
+          return false unless parameter_matches?(k, v)
+        end
+        true
+      end
+    end
+
     def methods
       @methods.each_value
+    end
+
+    def static?
+      !dynamic?
     end
 
     def with_method(method)
@@ -17,6 +35,89 @@ module OpenapiContracts
     end
 
     private
+
+    def parameter_matches?(name, value)
+      parameter = @schema['parameters'].find { |p| p['name'] == name && p['in'] == 'path' }
+
+      return false unless parameter
+
+      case parameter.dig('schema', 'type')
+      when 'integer'
+        integer_parameter_matches?(parameter, value)
+      when 'number'
+        number_parameter_matches?(parameter, value)
+      when 'string'
+        string_parameter_matches?(parameter, value)
+      else
+        # Not yet implemented
+        false
+      end
+    end
+
+    def regexp_path
+      re = /\{(\S+)\}/
+      @path.gsub(re) { |placeholder|
+        placeholder.match(re) { |m| "(?<#{m[1]}>[^/]*)" }
+      }.then { |str| Regexp.new(str) }
+    end
+
+    def integer_parameter_matches?(parameter, value)
+      return false unless /^-?\d+$/.match?(value)
+
+      parsed = value.to_i
+      return false unless minimum_number_matches?(parameter, parsed)
+      return false unless maximum_number_matches?(parameter, parsed)
+
+      true
+    end
+
+    def number_parameter_matches?(parameter, value)
+      return false unless /^-?(\d+\.)?\d+$/.match?(value)
+
+      parsed = value.to_f
+      return false unless minimum_number_matches?(parameter, parsed)
+      return false unless maximum_number_matches?(parameter, parsed)
+
+      true
+    end
+
+    def minimum_number_matches?(parameter, value)
+      if (min = parameter.dig('schema', 'minimum'))
+        if parameter.dig('schema', 'exclusiveMinimum')
+          return false if value <= min
+        elsif value < min
+          return false
+        end
+      end
+      true
+    end
+
+    def maximum_number_matches?(parameter, value)
+      if (max = parameter.dig('schema', 'maximum'))
+        if parameter.dig('schema', 'exclusiveMaximum')
+          return false if value >= max
+        elsif value > max
+          return false
+        end
+      end
+      true
+    end
+
+    def string_parameter_matches?(parameter, value)
+      if (pat = parameter.dig('schema', 'pattern'))
+        Regexp.new(pat).match?(value)
+      else
+        if (min = parameter.dig('schema', 'minLength')) && (value.length < min)
+          return false
+        end
+
+        if (max = parameter.dig('schema', 'maxLength')) && (value.length > max)
+          return false
+        end
+
+        true
+      end
+    end
 
     def known_http_methods
       # https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods

--- a/lib/openapi_contracts/doc/path.rb
+++ b/lib/openapi_contracts/doc/path.rb
@@ -37,21 +37,13 @@ module OpenapiContracts
     private
 
     def parameter_matches?(name, value)
-      parameter = @schema['parameters']&.find { |p| p['name'] == name && p['in'] == 'path' }
+      parameter = @schema['parameters']
+        &.find { |p| p['name'] == name && p['in'] == 'path' }
+        &.then { |s| Doc::Parameter.new(s.with_indifferent_access) }
 
       return false unless parameter
 
-      case parameter.dig('schema', 'type')
-      when 'integer'
-        integer_parameter_matches?(parameter, value)
-      when 'number'
-        number_parameter_matches?(parameter, value)
-      when 'string'
-        string_parameter_matches?(parameter, value)
-      else
-        # Not yet implemented
-        false
-      end
+      parameter.matches?(value)
     end
 
     def regexp_path
@@ -59,64 +51,6 @@ module OpenapiContracts
       @path.gsub(re) { |placeholder|
         placeholder.match(re) { |m| "(?<#{m[1]}>[^/]*)" }
       }.then { |str| Regexp.new(str) }
-    end
-
-    def integer_parameter_matches?(parameter, value)
-      return false unless /^-?\d+$/.match?(value)
-
-      parsed = value.to_i
-      return false unless minimum_number_matches?(parameter, parsed)
-      return false unless maximum_number_matches?(parameter, parsed)
-
-      true
-    end
-
-    def number_parameter_matches?(parameter, value)
-      return false unless /^-?(\d+\.)?\d+$/.match?(value)
-
-      parsed = value.to_f
-      return false unless minimum_number_matches?(parameter, parsed)
-      return false unless maximum_number_matches?(parameter, parsed)
-
-      true
-    end
-
-    def minimum_number_matches?(parameter, value)
-      if (min = parameter.dig('schema', 'minimum'))
-        if parameter.dig('schema', 'exclusiveMinimum')
-          return false if value <= min
-        elsif value < min
-          return false
-        end
-      end
-      true
-    end
-
-    def maximum_number_matches?(parameter, value)
-      if (max = parameter.dig('schema', 'maximum'))
-        if parameter.dig('schema', 'exclusiveMaximum')
-          return false if value >= max
-        elsif value > max
-          return false
-        end
-      end
-      true
-    end
-
-    def string_parameter_matches?(parameter, value)
-      if (pat = parameter.dig('schema', 'pattern'))
-        Regexp.new(pat).match?(value)
-      else
-        if (min = parameter.dig('schema', 'minLength')) && (value.length < min)
-          return false
-        end
-
-        if (max = parameter.dig('schema', 'maxLength')) && (value.length > max)
-          return false
-        end
-
-        true
-      end
     end
 
     def known_http_methods

--- a/lib/openapi_contracts/doc/path.rb
+++ b/lib/openapi_contracts/doc/path.rb
@@ -37,7 +37,7 @@ module OpenapiContracts
     private
 
     def parameter_matches?(name, value)
-      parameter = @schema['parameters'].find { |p| p['name'] == name && p['in'] == 'path' }
+      parameter = @schema['parameters']&.find { |p| p['name'] == name && p['in'] == 'path' }
 
       return false unless parameter
 

--- a/lib/openapi_contracts/validators/body.rb
+++ b/lib/openapi_contracts/validators/body.rb
@@ -23,9 +23,9 @@ module OpenapiContracts::Validators
 
     def error_to_message(error)
       if error.key?('details')
-        error['details'].to_a.map do |(key, val)|
+        error['details'].to_a.map { |(key, val)|
           "#{key.humanize}: #{val} at #{error['data_pointer']}"
-        end.to_sentence
+        }.to_sentence
       else
         "#{error['data'].inspect} at #{error['data_pointer']} does not match the schema"
       end

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -7,6 +7,9 @@ require: rubocop-rspec
 Metrics/BlockLength:
   Enabled: false
 
+RSpec/DescribeClass:
+  Exclude:
+  - integration/**/*
 RSpec/MultipleExpectations:
   Enabled: false
 RSpec/MultipleMemoizedHelpers:

--- a/spec/fixtures/openapi/paths/message.yaml
+++ b/spec/fixtures/openapi/paths/message.yaml
@@ -1,16 +1,18 @@
+parameters:
+- name: id
+  in: path
+  description: Id of the message.
+  required: true
+  schema:
+    type: string
+    pattern: '^[a-f,0-9]{8}$'
+    minLength: 8
 get:
   tags:
     - Message
   summary: Get Message
   description: Get Message
   operationId: get_message
-  parameters:
-  - name: id
-    in: path
-    description: Id of the message.
-    required: true
-    schema:
-      type: string
   responses:
     '200':
       description: OK

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'RSpec integration' do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'RSpec integration' do
   subject { response }
 
   include_context 'when using GET /user'
@@ -21,6 +21,23 @@ RSpec.describe 'RSpec integration' do # rubocop:disable RSpec/DescribeClass
   end
 
   context 'when using dynamic paths' do
+    let(:path) { '/messages/ef278ab2' }
+    let(:response_json) do
+      {
+        data: {
+          id:         '1ef',
+          type:       'messages',
+          attributes: {
+            body: 'foo'
+          }
+        }
+      }
+    end
+
+    it { is_expected.to match_openapi_doc(doc).with_http_status(:ok) }
+  end
+
+  context 'when using dynamic paths with path option' do
     let(:path) { '/messages/ef278' }
     let(:response_json) do
       {

--- a/spec/openapi_contracts/doc/parameter_spec.rb
+++ b/spec/openapi_contracts/doc/parameter_spec.rb
@@ -1,0 +1,230 @@
+RSpec.describe OpenapiContracts::Doc::Parameter do
+  subject(:parameter) { described_class.new(options) }
+
+  let(:options) do
+    {
+      name:   'something',
+      schema: schema
+    }
+  end
+
+  shared_examples 'a path parameter' do |expectations|
+    expectations.each do |k, v|
+      context "when the value is #{k.inspect}" do
+        let(:value) { k }
+
+        it { is_expected.to be v }
+      end
+    end
+  end
+
+  describe '#matches?(value)' do
+    subject { parameter.matches?(value) }
+
+    context 'when the param is a string with pattern' do
+      let(:schema) do
+        {
+          'type'    => 'string',
+          'pattern' => '^[a-f,0-9]{8}$'
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234abcd' => true,
+        '123'      => false
+      }
+    end
+
+    context 'when the param is a string with length' do
+      let(:schema) do
+        {
+          'type'      => 'string',
+          'minLength' => 4,
+          'maxLength' => 8
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'      => true,
+        '12'        => false,
+        '123456789' => false
+      }
+    end
+
+    context 'when the param is a integer' do
+      let(:schema) do
+        {
+          'type' => 'integer'
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'   => true,
+        '1.234'  => false,
+        'word'   => false,
+        '-1234'  => true,
+        '-1.234' => false
+      }
+    end
+
+    context 'when the param is a integer with minimum -2' do
+      let(:schema) do
+        {
+          'type'    => 'integer',
+          'minimum' => -2
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'  => true,
+        '-2'    => true,
+        '-1234' => false
+      }
+    end
+
+    context 'when the param is a integer with exclusive minimum -2' do
+      let(:schema) do
+        {
+          'type'             => 'integer',
+          'minimum'          => -2,
+          'exclusiveMinimum' => true
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '0'  => true,
+        '-2' => false
+      }
+    end
+
+    context 'when the param is a integer with maximum 2' do
+      let(:schema) do
+        {
+          'type'    => 'integer',
+          'maximum' => 2
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'  => false,
+        '2'     => true,
+        '-2'    => true,
+        '-1234' => true
+      }
+    end
+
+    context 'when the param is a integer with exclusive maximum 2' do
+      let(:schema) do
+        {
+          'type'             => 'integer',
+          'maximum'          => 2,
+          'exclusiveMaximum' => true
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '2' => false,
+        '0' => true
+      }
+    end
+
+    context 'when the param is a integer with minimum 0 and maximum 1234' do
+      let(:schema) do
+        {
+          'type'    => 'integer',
+          'minimum' => 0,
+          'maximum' => 1234
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'  => true,
+        '2'     => true,
+        '-2'    => false,
+        '-1234' => false
+      }
+    end
+
+    context 'when the param is a number' do
+      let(:schema) do
+        {
+          'type' => 'number'
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'   => true,
+        '1.234'  => true,
+        'word'   => false,
+        '-1234'  => true,
+        '-1.234' => true
+      }
+    end
+
+    context 'when the param is a number with minimum -2' do
+      let(:schema) do
+        {
+          'type'    => 'number',
+          'minimum' => -2
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'   => true,
+        '1.234'  => true,
+        'word'   => false,
+        '-1234'  => false,
+        '-1.234' => true
+      }
+    end
+
+    context 'when the param is a number with maximum 2' do
+      let(:schema) do
+        {
+          'type'    => 'number',
+          'maximum' => 2
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'   => false,
+        '1.234'  => true,
+        'word'   => false,
+        '-1234'  => true,
+        '-1.234' => true
+      }
+    end
+
+    context 'when the param is a number with minimum 0 and maximum 1000' do
+      let(:schema) do
+        {
+          'type'             => 'number',
+          'minimum'          => 0,
+          'maximum'          => 1000,
+          'exclusiveMaximum' => true
+        }
+      end
+
+      include_examples 'a path parameter', {
+        '1234'   => false,
+        '1.234'  => true,
+        'word'   => false,
+        '-1234'  => false,
+        '-1.234' => false
+      }
+    end
+
+    context 'when the param is a array' do
+      let(:schema) do
+        {
+          'type' => 'array'
+        }
+      end
+
+      # Array is not yet supported and will not match
+      include_examples 'a path parameter', {
+        '1,2,3' => false
+      }
+    end
+  end
+end

--- a/spec/openapi_contracts/doc/path_spec.rb
+++ b/spec/openapi_contracts/doc/path_spec.rb
@@ -64,131 +64,40 @@ RSpec.describe OpenapiContracts::Doc::Path do
       end
     end
 
-    context 'when the param is a integer' do
+    context 'when the param is a integer from 0 - 1000' do
       let(:id_schema) do
         {
-          'type' => 'integer'
+          'type'    => 'integer',
+          'minimum' => 0,
+          'maximum' => 1000
         }
       end
 
       it 'can match', :aggregate_failures do
-        expect(path.matches?('/messages/1234')).to be true
+        expect(path.matches?('/messages/1001')).to be false
+        expect(path.matches?('/messages/1000')).to be true
         expect(path.matches?('/messages/1.234')).to be false
-        expect(path.matches?('/messages/word')).to be false
-        expect(path.matches?('/messages/-1234')).to be true
+        expect(path.matches?('/messages/-1234')).to be false
         expect(path.matches?('/messages/-1.234')).to be false
-      end
-
-      context 'when there is a minimum' do
-        let(:id_schema) do
-          {
-            'type'    => 'number',
-            'minimum' => -2
-          }
-        end
-
-        it 'can match', :aggregate_failures do
-          expect(path.matches?('/messages/1234')).to be true
-          expect(path.matches?('/messages/-1234')).to be false
-        end
-      end
-
-      context 'when there is a maximum' do
-        let(:id_schema) do
-          {
-            'type'    => 'number',
-            'maximum' => 2
-          }
-        end
-
-        it 'can match', :aggregate_failures do
-          expect(path.matches?('/messages/1234')).to be false
-          expect(path.matches?('/messages/-1234')).to be true
-        end
-      end
-
-      context 'when there is a minimum and maximum' do
-        let(:id_schema) do
-          {
-            'type'    => 'number',
-            'minimum' => 0,
-            'maximum' => 1234
-          }
-        end
-
-        it 'can match', :aggregate_failures do
-          expect(path.matches?('/messages/1234')).to be true
-          expect(path.matches?('/messages/-1234')).to be false
-        end
       end
     end
 
-    context 'when the param is a number' do
+    context 'when the param is a number from 0 to 1000' do
       let(:id_schema) do
         {
-          'type' => 'number'
+          'type'             => 'number',
+          'minimum'          => 0,
+          'maximum'          => 1000,
+          'exclusiveMaximum' => true
         }
       end
 
       it 'can match', :aggregate_failures do
-        expect(path.matches?('/messages/1234')).to be true
+        expect(path.matches?('/messages/1000')).to be false
+        expect(path.matches?('/messages/999.9')).to be true
         expect(path.matches?('/messages/1.234')).to be true
         expect(path.matches?('/messages/word')).to be false
-        expect(path.matches?('/messages/-1234')).to be true
-        expect(path.matches?('/messages/-1.234')).to be true
-      end
-
-      context 'when there is a minimum' do
-        let(:id_schema) do
-          {
-            'type'    => 'number',
-            'minimum' => -2
-          }
-        end
-
-        it 'can match', :aggregate_failures do
-          expect(path.matches?('/messages/1234')).to be true
-          expect(path.matches?('/messages/1.234')).to be true
-          expect(path.matches?('/messages/word')).to be false
-          expect(path.matches?('/messages/-1234')).to be false
-          expect(path.matches?('/messages/-1.234')).to be true
-        end
-      end
-
-      context 'when there is a maximum' do
-        let(:id_schema) do
-          {
-            'type'    => 'number',
-            'maximum' => 2
-          }
-        end
-
-        it 'can match', :aggregate_failures do
-          expect(path.matches?('/messages/1234')).to be false
-          expect(path.matches?('/messages/1.234')).to be true
-          expect(path.matches?('/messages/word')).to be false
-          expect(path.matches?('/messages/-1234')).to be true
-          expect(path.matches?('/messages/-1.234')).to be true
-        end
-      end
-
-      context 'when there is a minimum and maximum' do
-        let(:id_schema) do
-          {
-            'type'             => 'number',
-            'minimum'          => 0,
-            'maximum'          => 1234,
-            'exclusiveMaximum' => true
-          }
-        end
-
-        it 'can match', :aggregate_failures do
-          expect(path.matches?('/messages/1234')).to be false
-          expect(path.matches?('/messages/1.234')).to be true
-          expect(path.matches?('/messages/word')).to be false
-          expect(path.matches?('/messages/-1234')).to be false
-          expect(path.matches?('/messages/-1.234')).to be false
-        end
+        expect(path.matches?('/messages/-1.234')).to be false
       end
     end
   end

--- a/spec/openapi_contracts/doc/path_spec.rb
+++ b/spec/openapi_contracts/doc/path_spec.rb
@@ -1,0 +1,195 @@
+RSpec.describe OpenapiContracts::Doc::Path do
+  subject(:path) { doc.with_path('/messages/{id}') }
+
+  let(:doc) { OpenapiContracts::Doc.new(schema) }
+  let(:schema) do
+    {
+      'paths' => {
+        '/messages/{id}' => {
+          'parameters' => [id_param].compact
+        }
+      }
+    }
+  end
+  let(:id_param) do
+    {
+      'name'     => 'id',
+      'in'       => 'path',
+      'required' => true,
+      'schema'   => id_schema
+    }
+  end
+  let(:id_schema) { {} }
+
+  describe '#dynamic?' do
+    subject { path.dynamic? }
+
+    it { is_expected.to be true }
+  end
+
+  describe '#static?' do
+    subject { path.static? }
+
+    it { is_expected.to be false }
+  end
+
+  describe '#matches?(path)' do
+    context 'when the param is a string with pattern' do
+      let(:id_schema) do
+        {
+          'type'    => 'string',
+          'pattern' => '^[a-f,0-9]{8}$'
+        }
+      end
+
+      it 'can match', :aggregate_failures do
+        expect(path.matches?('/messages/1234abcd')).to be true
+        expect(path.matches?('/messages/123')).to be false
+      end
+    end
+
+    context 'when the param is a string with length' do
+      let(:id_schema) do
+        {
+          'type'      => 'string',
+          'minLength' => 4,
+          'maxLength' => 8
+        }
+      end
+
+      it 'can match', :aggregate_failures do
+        expect(path.matches?('/messages/1234')).to be true
+        expect(path.matches?('/messages/12')).to be false
+        expect(path.matches?('/messages/123456789')).to be false
+      end
+    end
+
+    context 'when the param is a integer' do
+      let(:id_schema) do
+        {
+          'type' => 'integer'
+        }
+      end
+
+      it 'can match', :aggregate_failures do
+        expect(path.matches?('/messages/1234')).to be true
+        expect(path.matches?('/messages/1.234')).to be false
+        expect(path.matches?('/messages/word')).to be false
+        expect(path.matches?('/messages/-1234')).to be true
+        expect(path.matches?('/messages/-1.234')).to be false
+      end
+
+      context 'when there is a minimum' do
+        let(:id_schema) do
+          {
+            'type'    => 'number',
+            'minimum' => -2
+          }
+        end
+
+        it 'can match', :aggregate_failures do
+          expect(path.matches?('/messages/1234')).to be true
+          expect(path.matches?('/messages/-1234')).to be false
+        end
+      end
+
+      context 'when there is a maximum' do
+        let(:id_schema) do
+          {
+            'type'    => 'number',
+            'maximum' => 2
+          }
+        end
+
+        it 'can match', :aggregate_failures do
+          expect(path.matches?('/messages/1234')).to be false
+          expect(path.matches?('/messages/-1234')).to be true
+        end
+      end
+
+      context 'when there is a minimum and maximum' do
+        let(:id_schema) do
+          {
+            'type'    => 'number',
+            'minimum' => 0,
+            'maximum' => 1234
+          }
+        end
+
+        it 'can match', :aggregate_failures do
+          expect(path.matches?('/messages/1234')).to be true
+          expect(path.matches?('/messages/-1234')).to be false
+        end
+      end
+    end
+
+    context 'when the param is a number' do
+      let(:id_schema) do
+        {
+          'type' => 'number'
+        }
+      end
+
+      it 'can match', :aggregate_failures do
+        expect(path.matches?('/messages/1234')).to be true
+        expect(path.matches?('/messages/1.234')).to be true
+        expect(path.matches?('/messages/word')).to be false
+        expect(path.matches?('/messages/-1234')).to be true
+        expect(path.matches?('/messages/-1.234')).to be true
+      end
+
+      context 'when there is a minimum' do
+        let(:id_schema) do
+          {
+            'type'    => 'number',
+            'minimum' => -2
+          }
+        end
+
+        it 'can match', :aggregate_failures do
+          expect(path.matches?('/messages/1234')).to be true
+          expect(path.matches?('/messages/1.234')).to be true
+          expect(path.matches?('/messages/word')).to be false
+          expect(path.matches?('/messages/-1234')).to be false
+          expect(path.matches?('/messages/-1.234')).to be true
+        end
+      end
+
+      context 'when there is a maximum' do
+        let(:id_schema) do
+          {
+            'type'    => 'number',
+            'maximum' => 2
+          }
+        end
+
+        it 'can match', :aggregate_failures do
+          expect(path.matches?('/messages/1234')).to be false
+          expect(path.matches?('/messages/1.234')).to be true
+          expect(path.matches?('/messages/word')).to be false
+          expect(path.matches?('/messages/-1234')).to be true
+          expect(path.matches?('/messages/-1.234')).to be true
+        end
+      end
+
+      context 'when there is a minimum and maximum' do
+        let(:id_schema) do
+          {
+            'type'             => 'number',
+            'minimum'          => 0,
+            'maximum'          => 1234,
+            'exclusiveMaximum' => true
+          }
+        end
+
+        it 'can match', :aggregate_failures do
+          expect(path.matches?('/messages/1234')).to be false
+          expect(path.matches?('/messages/1.234')).to be true
+          expect(path.matches?('/messages/word')).to be false
+          expect(path.matches?('/messages/-1234')).to be false
+          expect(path.matches?('/messages/-1.234')).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Enables the matcher to resolve requests with dynamic path elements like `/user/123` to and endpoint like `/user/{id}`. Takes assertions on the path parameters into account.