### PR TITLE
Add request validation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First, parse your API documentation:
 
 ```ruby
 # This must point to the folder where the OAS file is stored
-$doc = OpenapiContracts::Doc.parse(Rails.root.join('spec', 'fixtures', 'openapi', 'api-docs'), '<filename>')
+$doc = OpenapiContracts::Doc.parse(Rails.root.join('spec/fixtures/openapi/api-docs'), '<filename>')
 ```
 
 In case the `filename` argument is not set, parser will by default search for the file named `openapi.yaml`.

--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@
 [![Gem Version](https://badge.fury.io/rb/openapi_contracts.svg)](https://badge.fury.io/rb/openapi_contracts)
 [![Depfu](https://badges.depfu.com/badges/8ac57411497df02584bbf59685634e45/overview.svg)](https://depfu.com/github/mkon/openapi_contracts?project_id=35354)
 
-Use openapi documentation as an api contract.
+Use OpenAPI documentation as an API contract.
 
 Currently supports OpenAPI documentation in the structure as used by [Redocly](https://github.com/Redocly/create-openapi-repo), but should also work for single file schemas.
 
-Adds RSpec matchers to easily verify that your responses match the OpenAPI documentation.
+Adds RSpec matchers to easily verify that your requests and responses match the OpenAPI documentation.
 
 ## Usage
 
-First parse your api documentation:
+First, parse your API documentation:
 
 ```ruby
-# This must point to the folder where the "openapi.yaml" file is
-$doc = OpenapiContracts::Doc.parse(Rails.root.join('spec/fixtures/openapi/api-docs/openapi'))
+# This must point to the folder where the OAS file is stored
+$doc = OpenapiContracts::Doc.parse(Rails.root.join('spec', 'fixtures', 'openapi', 'api-docs'), '<filename>')
 ```
 
-Ideally you do this once in a RSpec `before(:suite)` hook.
+In case the `filename` argument is not set, parser will by default search for the file named `openapi.yaml`.
 
-Then you can use these matchers in your request specs:
+Ideally you do this once in an RSpec `before(:suite)` hook. Then you can use these matchers in your request specs:
 
 ```ruby
 subject { make_request and response }
@@ -34,32 +34,40 @@ it { is_expected.to match_openapi_doc($doc) }
 You can assert a specific http status to make sure the response is of the right status:
 
 ```ruby
-it { is_expected.to match_openapi_doc($api_doc).with_http_status(:ok) }
+it { is_expected.to match_openapi_doc($doc).with_http_status(:ok) }
 
-# this is equal to
+# This is equal to
 it 'responds with 200 and matches the doc' do
   expect(subject).to have_http_status(:ok)
-  expect(subject).to match_openapi_doc($api_doc)
-}
+  expect(subject).to match_openapi_doc($doc)
+end
 ```
 
 ### Options
 
 The `match_openapi_doc($doc)` method allows passing options as a 2nd argument.
-This allows overriding the default request.path lookup in case this does not find
-the correct response definition in your schema. This can be usefull when there is
-dynamic parameters in the path and the matcher fails to resolve the request path to
-an endpoint in the openapi specification.
 
-Example:
+* `path` allows overriding the default `request.path` lookup in case it does not find the
+  correct response definition in your schema. This is especially important when there are
+  dynamic parameters in the path and the matcher fails to resolve the request path to
+  an endpoint in the OAS file.
 
 ```ruby
-it { is_expected.to match_openapi_doc($api_doc, path: '/messages/{id}').with_http_status(:ok) }
+it { is_expected.to match_openapi_doc($doc, path: '/messages/{id}').with_http_status(:ok) }
 ```
+
+* `request_body` can be set to `true` in case the validation of the request body against the OpenAPI _requestBody_ schema is required.
+
+```ruby
+it { is_expected.to match_openapi_doc($doc, request_body: true).with_http_status(:created) }
+```
+
+Both options can as well be used simultaneously.
 
 ### Without RSpec
 
 You can also use the Validator directly:
+
 ```ruby
 # Let's raise an error if the response does not match
 result = OpenapiContracts.match($doc, response, options = {})
@@ -69,16 +77,16 @@ raise result.errors.merge("/n") unless result.valid?
 ### How it works
 
 It uses the `request.path`, `request.method`, `status` and `headers` on the test subject
-(which must be the response) to find the response schema in the OpenAPI document.
+(which must be the response) to find the request and response schemas in the OpenAPI document.
 Then it does the following checks:
 
 * The response is documented
 * Required headers are present
 * Documented headers match the schema (via json_schemer)
 * The response body matches the schema (via json_schemer)
+* The request body matches the schema (via json_schemer) - if `request_body: true`
 
 ## Future plans
 
-* Validate sent requests against the request schema
 * Validate Webmock stubs against the OpenAPI doc
 * Generate example payloads from the OpenAPI doc

--- a/lib/openapi_contracts.rb
+++ b/lib/openapi_contracts.rb
@@ -14,7 +14,7 @@ module OpenapiContracts
   autoload :Match,      'openapi_contracts/match'
   autoload :Validators, 'openapi_contracts/validators'
 
-  Env = Struct.new(:spec, :response, :expected_status)
+  Env = Struct.new(:spec, :response, :expected_status, :request_body_required?, :request_body)
 
   module_function
 

--- a/lib/openapi_contracts.rb
+++ b/lib/openapi_contracts.rb
@@ -14,7 +14,7 @@ module OpenapiContracts
   autoload :Match,      'openapi_contracts/match'
   autoload :Validators, 'openapi_contracts/validators'
 
-  Env = Struct.new(:spec, :response, :expected_status, :request_body_required?, :request_body)
+  Env = Struct.new(:spec, :response, :expected_status, :match_request_body?, :request_body)
 
   module_function
 

--- a/lib/openapi_contracts/doc.rb
+++ b/lib/openapi_contracts/doc.rb
@@ -6,6 +6,7 @@ module OpenapiContracts
     autoload :Parser,     'openapi_contracts/doc/parser'
     autoload :Parameter,  'openapi_contracts/doc/parameter'
     autoload :Path,       'openapi_contracts/doc/path'
+    autoload :Request,    'openapi_contracts/doc/request'
     autoload :Response,   'openapi_contracts/doc/response'
     autoload :Schema,     'openapi_contracts/doc/schema'
 
@@ -30,6 +31,10 @@ module OpenapiContracts
 
     def response_for(path, method, status)
       with_path(path)&.with_method(method)&.with_status(status)
+    end
+
+    def request_for(path, method)
+      with_path(path)&.with_method(method)&.request_body
     end
 
     # Returns an Enumerator over all Responses

--- a/lib/openapi_contracts/doc/method.rb
+++ b/lib/openapi_contracts/doc/method.rb
@@ -2,10 +2,13 @@ module OpenapiContracts
   class Doc::Method
     def initialize(schema)
       @schema = schema
+      @request_body = Doc::Request.new(schema.navigate('requestBody')) if schema['requestBody'].present?
       @responses = schema['responses'].to_h do |status, _|
         [status, Doc::Response.new(schema.navigate('responses', status))]
       end
     end
+
+    attr_reader :request_body
 
     def responses
       @responses.each_value

--- a/lib/openapi_contracts/doc/request.rb
+++ b/lib/openapi_contracts/doc/request.rb
@@ -1,0 +1,17 @@
+module OpenapiContracts
+  class Doc::Request
+    def initialize(schema)
+      @schema = schema.follow_refs
+    end
+
+    def schema_for(content_type)
+      return unless supports_content_type?(content_type)
+
+      @schema.navigate('content', content_type, 'schema')
+    end
+
+    def supports_content_type?(content_type)
+      @schema.dig('content', content_type).present?
+    end
+  end
+end

--- a/lib/openapi_contracts/match.rb
+++ b/lib/openapi_contracts/match.rb
@@ -17,18 +17,34 @@ module OpenapiContracts
 
     private
 
-    def lookup_api_spec
-      @doc.response_for(
-        @options.fetch(:path, @response.request.path),
-        @response.request.request_method.downcase,
-        @response.status.to_s
-      )
+    def response_spec
+      @doc.response_for(path, method, status)
+    end
+
+    def request_spec
+      @doc.request_for(path, method)
     end
 
     def matchers
-      env = Env.new(lookup_api_spec, @response, @options[:status])
+      env = Env.new(response_spec, @response, @options[:status], request_body_required?, request_spec)
       Validators::ALL.reverse
                      .reduce(->(err) { err }) { |s, m| m.new(s, env) }
+    end
+
+    def request_body_required?
+      @options.fetch(:request_body, false)
+    end
+
+    def path
+      @options.fetch(:path, @response.request.path)
+    end
+
+    def method
+      @response.request.request_method.downcase
+    end
+
+    def status
+      @response.status.to_s
     end
   end
 end

--- a/lib/openapi_contracts/match.rb
+++ b/lib/openapi_contracts/match.rb
@@ -26,12 +26,12 @@ module OpenapiContracts
     end
 
     def matchers
-      env = Env.new(response_spec, @response, @options[:status], request_body_required?, request_spec)
+      env = Env.new(response_spec, @response, @options[:status], match_request_body?, request_spec)
       Validators::ALL.reverse
                      .reduce(->(err) { err }) { |s, m| m.new(s, env) }
     end
 
-    def request_body_required?
+    def match_request_body?
       @options.fetch(:request_body, false)
     end
 

--- a/lib/openapi_contracts/rspec.rb
+++ b/lib/openapi_contracts/rspec.rb
@@ -14,12 +14,12 @@ RSpec::Matchers.define :match_openapi_doc do |doc, options = {}| # rubocop:disab
   end
 
   description do
-    desc = 'to match the openapi schema'
+    desc = 'match the openapi schema'
     desc << " with #{http_status_desc(@status)}" if @status
     desc
   end
 
-  failure_message do |_reponse|
+  failure_message do |_response|
     @errors.map { |e| "* #{e}" }.join("\n")
   end
 

--- a/lib/openapi_contracts/validators.rb
+++ b/lib/openapi_contracts/validators.rb
@@ -5,11 +5,13 @@ module OpenapiContracts
     autoload :Documented, 'openapi_contracts/validators/documented'
     autoload :Headers,    'openapi_contracts/validators/headers'
     autoload :HttpStatus, 'openapi_contracts/validators/http_status'
+    autoload :Request, 'openapi_contracts/validators/request'
 
     # Defines order of matching
     ALL = [
       Documented,
       HttpStatus,
+      Request,
       Body,
       Headers
     ].freeze

--- a/lib/openapi_contracts/validators/base.rb
+++ b/lib/openapi_contracts/validators/base.rb
@@ -22,7 +22,7 @@ module OpenapiContracts::Validators
 
     private
 
-    delegate :request_body, :request_body_required?, :expected_status, :response, :spec, to: :@env
+    delegate :request_body, :match_request_body?, :expected_status, :response, :spec, to: :@env
 
     # :nocov:
     def validate

--- a/lib/openapi_contracts/validators/base.rb
+++ b/lib/openapi_contracts/validators/base.rb
@@ -22,7 +22,7 @@ module OpenapiContracts::Validators
 
     private
 
-    delegate :expected_status, :response, :spec, to: :@env
+    delegate :request_body, :request_body_required?, :expected_status, :response, :spec, to: :@env
 
     # :nocov:
     def validate

--- a/lib/openapi_contracts/validators/documented.rb
+++ b/lib/openapi_contracts/validators/documented.rb
@@ -5,8 +5,8 @@ module OpenapiContracts::Validators
     private
 
     def validate
-      request_missing if request_body_required? && !request_body
-      spec ? return : response_missing
+      response_missing unless spec
+      request_missing if match_request_body? && !request_body
     end
 
     def response_missing

--- a/lib/openapi_contracts/validators/documented.rb
+++ b/lib/openapi_contracts/validators/documented.rb
@@ -5,10 +5,17 @@ module OpenapiContracts::Validators
     private
 
     def validate
-      return if spec
+      request_missing if request_body_required? && !request_body
+      spec ? return : response_missing
+    end
 
+    def response_missing
       status_desc = http_status_desc(response.status)
-      @errors << "Undocumented request/response for #{response_desc.inspect} with #{status_desc}"
+      @errors << "Undocumented response for #{response_desc.inspect} with #{status_desc}"
+    end
+
+    def request_missing
+      @errors << "Undocumented request body for #{response_desc.inspect}"
     end
 
     def response_desc

--- a/lib/openapi_contracts/validators/documented.rb
+++ b/lib/openapi_contracts/validators/documented.rb
@@ -19,7 +19,7 @@ module OpenapiContracts::Validators
     end
 
     def response_desc
-      "#{response.request.request_method} #{response.request.path}"
+      "#{request.request_method} #{request.path}"
     end
   end
 end

--- a/lib/openapi_contracts/validators/request.rb
+++ b/lib/openapi_contracts/validators/request.rb
@@ -3,7 +3,7 @@ module OpenapiContracts::Validators
     private
 
     def validate
-      validate_schema if request_body_required?
+      validate_schema if match_request_body?
     end
 
     def validate_schema

--- a/lib/openapi_contracts/validators/request.rb
+++ b/lib/openapi_contracts/validators/request.rb
@@ -14,7 +14,7 @@ module OpenapiContracts::Validators
       else
         schema = request_body.schema_for(request_content_type)
         # Trick JSONSchemer into validating only against the request body schema
-        schemer = JSONSchemer.schema(schema.raw.merge('$ref' => schema.fragment))
+        schemer = JSONSchemer.schema(schema.raw.merge('$ref' => schema.fragment, '$schema' => 'http://json-schema.org/draft-04/schema#'))
         schemer.validate(JSON(request_payload)).each do |err|
           @errors << error_to_message(err)
         end

--- a/lib/openapi_contracts/validators/request.rb
+++ b/lib/openapi_contracts/validators/request.rb
@@ -1,0 +1,42 @@
+module OpenapiContracts::Validators
+  class Request < Base
+    private
+
+    def validate
+      validate_schema if request_body_required?
+    end
+
+    def validate_schema
+      if !request_body
+        @errors << 'No request body found'
+      elsif !request_body.supports_content_type?(request_content_type)
+        @errors << "Undocumented request with content-type #{request_content_type.inspect}"
+      else
+        schema = request_body.schema_for(request_content_type)
+        # Trick JSONSchemer into validating only against the request body schema
+        schemer = JSONSchemer.schema(schema.raw.merge('$ref' => schema.fragment))
+        schemer.validate(JSON(request_payload)).each do |err|
+          @errors << error_to_message(err)
+        end
+      end
+    end
+
+    def request_payload
+      response.request.env['PARAMS'] || response.request.body.read
+    end
+
+    def error_to_message(error)
+      if error.key?('details')
+        error['details'].to_a.map { |(key, val)|
+          "#{key.humanize}: #{val} at #{error['data_pointer']}"
+        }.to_sentence
+      else
+        "#{error['data'].inspect} at #{error['data_pointer']} does not match the request schema"
+      end
+    end
+
+    def request_content_type
+      response.headers['Content-Type'].split(';').first
+    end
+  end
+end

--- a/spec/fixtures/openapi/openapi.yaml
+++ b/spec/fixtures/openapi/openapi.yaml
@@ -5,10 +5,10 @@ info:
   termsOfService: 'https://example.com/terms/'
   contact:
     email: contact@example.com
-    url: 'http://example.com/contact'
+    url: 'https://example.com/contact'
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   x-logo:
     url: 'https://redocly.github.io/openapi-template/logo.png'
   description: >
@@ -48,8 +48,7 @@ paths:
         '400':
           $ref: components/responses/BadRequest.yaml
         '409':
-           description: Conflict
-           $ref: '#/components/responses/GenericError'
+          $ref: '#/components/responses/GenericError'
         '500':
           description: Server Error
   /numbers:
@@ -62,7 +61,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: components/schemas/Numbers.yaml#/All
+                $ref: 'components/schemas/Numbers.yaml#/All'
   /messages/{id}:
     $ref: 'paths/message.yaml'
   /comments/{id}:

--- a/spec/fixtures/openapi/paths/user.yaml
+++ b/spec/fixtures/openapi/paths/user.yaml
@@ -24,3 +24,59 @@ get:
             additionalProperties: false
     '400':
       $ref: ../components/responses/BadRequest.yaml
+post:
+  tags:
+    - User
+  summary: Create User
+  description: Create User
+  operationId: create_user
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              type: object
+              properties:
+                type:
+                  type: string
+                attributes:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      nullable: true
+                    email:
+                      $ref: ../components/schemas/Email.yaml
+                  additionalProperties: false
+                  required:
+                    - name
+                    - email
+              additionalProperties: false
+              required:
+                - type
+                - attributes
+          required:
+            - data
+          additionalProperties: false
+  responses:
+    '201':
+      description: Created
+      headers:
+        x-request-id:
+          schema:
+            type: string
+          required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: ../components/schemas/User.yaml
+            required:
+              - data
+            additionalProperties: false
+    '400':
+      $ref: ../components/responses/BadRequest.yaml

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'RSpec integration' do
     it { is_expected.to_not match_openapi_doc(doc) }
   end
 
-  context 'when an additinal attribute is included' do
+  context 'when an additional attribute is included' do
     before { response_json[:data][:attributes].merge!(other: 'foo') }
 
     it { is_expected.to_not match_openapi_doc(doc) }
@@ -94,5 +94,13 @@ RSpec.describe 'RSpec integration' do
     let(:method) { 'POST' }
 
     it { is_expected.to_not match_openapi_doc(doc) }
+  end
+
+  context 'when request body is validated' do
+    include_context 'when using POST /user'
+
+    it { is_expected.to match_openapi_doc(doc, path: '/user', request_body: true).with_http_status(:created) }
+
+    it { is_expected.to_not match_openapi_doc(doc, path: '/user', request_body: true).with_http_status(:ok) }
   end
 end

--- a/spec/openapi_contracts/doc/file_parser_spec.rb
+++ b/spec/openapi_contracts/doc/file_parser_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe OpenapiContracts::Doc::FileParser do
       subject { result.to_mergable_hash.to_json }
 
       it { is_expected.to be_json_eql(<<~JSON) }
-         {
+        {
           "paths": {
             "user": {
               "get": {

--- a/spec/openapi_contracts/doc/file_parser_spec.rb
+++ b/spec/openapi_contracts/doc/file_parser_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe OpenapiContracts::Doc::FileParser do
       subject { result.to_mergable_hash.to_json }
 
       it { is_expected.to be_json_eql(<<~JSON) }
-        {
+         {
           "paths": {
             "user": {
               "get": {
@@ -109,6 +109,91 @@ RSpec.describe OpenapiContracts::Doc::FileParser do
                   }
                 },
                 "summary": "Get User",
+                "tags": [
+                  "User"
+                ]
+              },
+              "post": {
+                "description": "Create User",
+                "operationId": "create_user",
+                "requestBody": {
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "data": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "attributes": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "email": {
+                                    "$ref": "#/components/schemas/Email"
+                                  },
+                                  "name": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "email"
+                                ],
+                                "type": "object"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "attributes"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "data"
+                        ],
+                        "type": "object"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "201": {
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "data": {
+                              "$ref": "#/components/schemas/User"
+                            }
+                          },
+                          "required": [
+                            "data"
+                          ],
+                          "type": "object"
+                        }
+                      }
+                    },
+                    "description": "Created",
+                    "headers": {
+                      "x-request-id": {
+                        "required": true,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "400": {
+                    "$ref": "#/components/responses/BadRequest"
+                  }
+                },
+                "summary": "Create User",
                 "tags": [
                   "User"
                 ]

--- a/spec/openapi_contracts/doc/parameter_spec.rb
+++ b/spec/openapi_contracts/doc/parameter_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe OpenapiContracts::Doc::Parameter do
       }
     end
 
-    context 'when the param is a integer' do
+    context 'when the param is an integer' do
       let(:schema) do
         {
           'type' => 'integer'
@@ -67,7 +67,7 @@ RSpec.describe OpenapiContracts::Doc::Parameter do
       }
     end
 
-    context 'when the param is a integer with minimum -2' do
+    context 'when the param is an integer with minimum -2' do
       let(:schema) do
         {
           'type'    => 'integer',
@@ -82,7 +82,7 @@ RSpec.describe OpenapiContracts::Doc::Parameter do
       }
     end
 
-    context 'when the param is a integer with exclusive minimum -2' do
+    context 'when the param is an integer with exclusive minimum -2' do
       let(:schema) do
         {
           'type'             => 'integer',
@@ -97,7 +97,7 @@ RSpec.describe OpenapiContracts::Doc::Parameter do
       }
     end
 
-    context 'when the param is a integer with maximum 2' do
+    context 'when the param is an integer with maximum 2' do
       let(:schema) do
         {
           'type'    => 'integer',
@@ -113,7 +113,7 @@ RSpec.describe OpenapiContracts::Doc::Parameter do
       }
     end
 
-    context 'when the param is a integer with exclusive maximum 2' do
+    context 'when the param is an integer with exclusive maximum 2' do
       let(:schema) do
         {
           'type'             => 'integer',
@@ -128,7 +128,7 @@ RSpec.describe OpenapiContracts::Doc::Parameter do
       }
     end
 
-    context 'when the param is a integer with minimum 0 and maximum 1234' do
+    context 'when the param is an integer with minimum 0 and maximum 1234' do
       let(:schema) do
         {
           'type'    => 'integer',
@@ -214,7 +214,7 @@ RSpec.describe OpenapiContracts::Doc::Parameter do
       }
     end
 
-    context 'when the param is a array' do
+    context 'when the param is an array' do
       let(:schema) do
         {
           'type' => 'array'

--- a/spec/openapi_contracts/doc/path_spec.rb
+++ b/spec/openapi_contracts/doc/path_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe OpenapiContracts::Doc::Path do
       end
     end
 
-    context 'when the param is a integer from 0 - 1000' do
+    context 'when the param is an integer from 0 - 1000' do
       let(:id_schema) do
         {
           'type'    => 'integer',

--- a/spec/openapi_contracts/doc/request_spec.rb
+++ b/spec/openapi_contracts/doc/request_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe OpenapiContracts::Doc::Request do
+  subject { doc.request_for(path, method) }
+
+  let(:doc) { OpenapiContracts::Doc.parse(FIXTURES_PATH.join('openapi')) }
+
+  let(:request) { doc.request_for('/user', 'post') }
+
+  describe '#supports_content_type?' do
+    subject { request.supports_content_type?(content_type) }
+
+    context 'when content_type is supported' do
+      let(:content_type) { 'application/json' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when content_type is not supported' do
+      let(:content_type) { 'application/text' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#schema_for' do
+    subject { request.schema_for(content_type) }
+
+    context 'when content_type is supported' do
+      let(:content_type) { 'application/json' }
+
+      it { is_expected.to be_a(OpenapiContracts::Doc::Schema) }
+    end
+
+    context 'when content_type is not supported' do
+      let(:content_type) { 'application/text' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/openapi_contracts/doc/response_spec.rb
+++ b/spec/openapi_contracts/doc/response_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe OpenapiContracts::Doc::Response do
     describe '#supports_content_type?' do
       subject { response.supports_content_type?(content_type) }
 
-      context 'when content_type is supprted' do
+      context 'when content_type is supported' do
         let(:content_type) { 'application/json' }
 
         it { is_expected.to be true }
       end
 
-      context 'when content_type is not supprted' do
+      context 'when content_type is not supported' do
         let(:content_type) { 'application/text' }
 
         it { is_expected.to be false }
@@ -47,7 +47,7 @@ RSpec.describe OpenapiContracts::Doc::Response do
     describe '#schema_for' do
       subject { response.schema_for(content_type) }
 
-      context 'when content_type is supprted' do
+      context 'when content_type is supported' do
         let(:content_type) { 'application/json' }
 
         it { is_expected.to be_a(OpenapiContracts::Doc::Schema) }

--- a/spec/openapi_contracts/doc_spec.rb
+++ b/spec/openapi_contracts/doc_spec.rb
@@ -30,6 +30,6 @@ RSpec.describe OpenapiContracts::Doc do
 
     it { is_expected.to all be_a(OpenapiContracts::Doc::Response) }
 
-    it { is_expected.to have_attributes(count: 11) }
+    it { is_expected.to have_attributes(count: 13) }
   end
 end

--- a/spec/openapi_contracts/validators/documented_spec.rb
+++ b/spec/openapi_contracts/validators/documented_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe OpenapiContracts::Validators::Documented do
   subject { described_class.new(stack, env) }
 
   let(:env) {
-    OpenapiContracts::Env.new(spec: spec, response: response, expected_status: 204,
+    OpenapiContracts::Env.new(spec: spec, response: response, request: response.request, expected_status: 204,
                               match_request_body?: match_request_body?, request_body: request_body)
   }
   let(:spec) { doc.response_for(path, method.downcase, response_status.to_s) }

--- a/spec/openapi_contracts/validators/documented_spec.rb
+++ b/spec/openapi_contracts/validators/documented_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe OpenapiContracts::Validators::Documented do
+  subject { described_class.new(stack, env) }
+
+  let(:env) { OpenapiContracts::Env.new(spec, response, 204, request_body_required?, request_body) }
+  let(:spec) { doc.response_for(path, method.downcase, response_status.to_s) }
+  let(:request_body) { doc.request_for(path, method.downcase) }
+  let(:stack) { ->(errors) { errors } }
+
+  include_context 'when using GET /user'
+
+  context 'when the request body is not documented' do
+    let(:request_body_required?) { true }
+
+    it 'returns an error' do
+      expect(subject.call).to eq ['Undocumented request body for "GET /user"']
+    end
+  end
+
+  context 'when the response is not documented' do
+    let(:request_body_required?) { false }
+    let(:response_status) { 204 }
+
+    it 'returns an error' do
+      expect(subject.call).to eq ['Undocumented response for "GET /user" with http status No Content (204)']
+    end
+  end
+end

--- a/spec/openapi_contracts/validators/documented_spec.rb
+++ b/spec/openapi_contracts/validators/documented_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe OpenapiContracts::Validators::Documented do
   subject { described_class.new(stack, env) }
 
-  let(:env) { OpenapiContracts::Env.new(spec, response, 204, request_body_required?, request_body) }
+  let(:env) { OpenapiContracts::Env.new(spec, response, 204, match_request_body?, request_body) }
   let(:spec) { doc.response_for(path, method.downcase, response_status.to_s) }
   let(:request_body) { doc.request_for(path, method.downcase) }
   let(:stack) { ->(errors) { errors } }
@@ -9,7 +9,7 @@ RSpec.describe OpenapiContracts::Validators::Documented do
   include_context 'when using GET /user'
 
   context 'when the request body is not documented' do
-    let(:request_body_required?) { true }
+    let(:match_request_body?) { true }
 
     it 'returns an error' do
       expect(subject.call).to eq ['Undocumented request body for "GET /user"']
@@ -17,7 +17,7 @@ RSpec.describe OpenapiContracts::Validators::Documented do
   end
 
   context 'when the response is not documented' do
-    let(:request_body_required?) { false }
+    let(:match_request_body?) { false }
     let(:response_status) { 204 }
 
     it 'returns an error' do

--- a/spec/openapi_contracts/validators/request_spec.rb
+++ b/spec/openapi_contracts/validators/request_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe OpenapiContracts::Validators::Request do
   subject { described_class.new(stack, env) }
 
   let(:env) {
-    OpenapiContracts::Env.new(spec: spec, response: response, request: response.request, expected_status: 201, match_request_body?: true,
-                              request_body: req)
+    OpenapiContracts::Env.new(spec: spec, response: response, request: response.request,
+                              expected_status: 201, match_request_body?: true, request_body: req)
   }
   let(:spec) { doc.response_for(path, method.downcase, response_status.to_s) }
   let(:req) { doc.request_for(path, method.downcase) }

--- a/spec/openapi_contracts/validators/request_spec.rb
+++ b/spec/openapi_contracts/validators/request_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe OpenapiContracts::Validators::Request do
+  subject { described_class.new(stack, env) }
+
+  let(:env) { OpenapiContracts::Env.new(spec, response, 201, true, req) }
+  let(:spec) { doc.response_for(path, method.downcase, response_status.to_s) }
+  let(:req) { doc.request_for(path, method.downcase) }
+  let(:stack) { ->(errors) { errors } }
+
+  include_context 'when using POST /user'
+
+  context 'when the request body matches the schema' do
+    it 'has no errors' do
+      expect(subject.call).to be_empty
+    end
+  end
+
+  context 'when having multiple errors' do
+    let(:request_json) do
+      {
+        data: {
+          id:         'a2kfn2',
+          type:       nil,
+          attributes: {
+            name: 'Joe'
+          }
+        }
+      }
+    end
+
+    it 'returns all errors' do
+      expect(subject.call).to eq [
+        '"a2kfn2" at /data/id does not match the request schema',
+        'nil at /data/type does not match the request schema',
+        'Missing keys: ["email"] at /data/attributes'
+      ]
+    end
+  end
+
+  context 'when the request body has a different content type' do
+    before do
+      response_headers['Content-Type'] = 'application/xml'
+    end
+
+    let(:response_body) { '<xml\>' }
+
+    it 'returns an error' do
+      expect(subject.call).to eq ['Undocumented request with content-type "application/xml"']
+    end
+  end
+
+  context 'when the request body should exist but does not' do
+    let(:path) { '/messages' }
+
+    it 'returns an error' do
+      expect(subject.call).to eq ['No request body found']
+    end
+  end
+end

--- a/spec/support/setup_context.rb
+++ b/spec/support/setup_context.rb
@@ -29,3 +29,51 @@ RSpec.shared_context 'when using GET /user' do
   end
   let(:response_status) { 200 }
 end
+
+RSpec.shared_context 'when using POST /user' do
+  let(:response) {
+    TestResponse.new(
+      Rack::MockResponse.new(response_status, response_headers, response_body),
+      Rack::Request.new({
+                          'PATH_INFO'      => path,
+                          'REQUEST_METHOD' => method.to_s.upcase,
+                          'PARAMS'         => request_body
+                        })
+    )
+  }
+  let(:doc) { OpenapiContracts::Doc.parse(FIXTURES_PATH.join('openapi')) }
+  let(:method) { 'POST' }
+  let(:path) { '/user' }
+  let(:response_body) { JSON.dump(response_json) }
+  let(:request_body) { JSON.dump(request_json) }
+  let(:response_headers) do
+    {
+      'Content-Type' => 'application/json',
+      'X-Request-Id' => 'some-request-id'
+    }
+  end
+  let(:request_json) do
+    {
+      data: {
+        type:       'user',
+        attributes: {
+          name:  'john',
+          email: 'name@me.example'
+        }
+      }
+    }
+  end
+  let(:response_json) do
+    {
+      data: {
+        id:         'some-id',
+        type:       'user',
+        attributes: {
+          name:  'john',
+          email: 'name@me.example'
+        }
+      }
+    }
+  end
+  let(:response_status) { 201 }
+end

--- a/spec/support/test_response.rb
+++ b/spec/support/test_response.rb
@@ -1,6 +1,6 @@
 require 'delegate'
 
-# TODO: Find a better way to work wiht both ActionDispatch and Rack::Test
+# TODO: Find a better way to work with both ActionDispatch and Rack::Test
 # Rack::Test can not access request from response
 class TestResponse < SimpleDelegator
   attr_reader :request


### PR DESCRIPTION
Hi @mkon, 

I prepared a PR that adds the request validation logic to the gem and I would love to hear your feedback. 

I added a new validator for requests and a Request class for looking up correct requests from the OAS file with appropriate tests. I also updated the README a bit and fixed some typos in the specs and warnings in the OAS files.

I just want to explain why I have decided to go with `request_body` as an option (similar to `path`). 
It's because not all HTTP methods have a request body. Of course, I could have implemented it in a way to validate the request body only for certain HTTP methods, or only if the request body exists in the OAS file or in the response. 

However, that would create another problem. When the user tests the unsuccessful responses (and usually there are more of them), he/she does not care if the request payload is the same as in the OAS file or not, even though it exists in both the OAS file and in the request itself. In most cases, an empty or any invalid payload will be used just to enforce an unsuccessful response. But if our request validation is not optional, all these validations of unsuccessful responses would always fail, making it inconvenient and unnecessarily hard for the user to test them (even though all responses need to be tested for proper contract testing).

Also, this way the newer version of the gem won't break anyone's existing specs and people won't hate us. 😄 

All of this results in the following usage: 
```ruby
it { is_expected.to match_openapi_doc($doc, request_body: true).with_http_status(:created) }
```

Please let me know what you think of my approach and my PR as well. Thanks!
