### PR TITLE
fix: parse multiple parameters

### DIFF
--- a/lib/openapi_contracts/doc/path.rb
+++ b/lib/openapi_contracts/doc/path.rb
@@ -22,7 +22,7 @@ module OpenapiContracts
 
     def path_regexp
       @path_regexp ||= begin
-        re = /\{(\S+)\}/
+        re = /\{([^\}]+)\}/
         @path.gsub(re) { |placeholder|
           placeholder.match(re) { |m| "(?<#{m[1]}>[^/]*)" }
         }.then { |str| Regexp.new(str) }

--- a/lib/openapi_contracts/doc/path.rb
+++ b/lib/openapi_contracts/doc/path.rb
@@ -25,7 +25,7 @@ module OpenapiContracts
         re = /\{([^\}]+)\}/
         @path.gsub(re) { |placeholder|
           placeholder.match(re) { |m| "(?<#{m[1]}>[^/]*)" }
-        }.then { |str| Regexp.new(str) }
+        }.then { |str| Regexp.new( "^#{str}$") }
       end
     end
 

--- a/lib/openapi_contracts/doc/path.rb
+++ b/lib/openapi_contracts/doc/path.rb
@@ -25,7 +25,7 @@ module OpenapiContracts
         re = /\{([^\}]+)\}/
         @path.gsub(re) { |placeholder|
           placeholder.match(re) { |m| "(?<#{m[1]}>[^/]*)" }
-        }.then { |str| Regexp.new( "^#{str}$") }
+        }.then { |str| Regexp.new("^#{str}$") }
       end
     end
 

--- a/spec/openapi_contracts/doc/path_spec.rb
+++ b/spec/openapi_contracts/doc/path_spec.rb
@@ -60,19 +60,18 @@ RSpec.describe OpenapiContracts::Doc::Path do
   end
 
   describe '#path_regexp' do
-    context "when there are two parameters" do
+    context 'when there are two parameters' do
       subject { doc.with_path('/messages/{id}/{second_id}').path_regexp.match('/messages/123/abc').captures }
 
       it 'matches both parameters' do
         expect(subject).to eq %w(123 abc)
       end
-
     end
 
-    context "when there is a trailing path" do
+    context 'when there is a trailing path' do
       subject { doc.with_path('/messages/{id}').path_regexp.match?('/messages/123/trailing') }
 
-      it 'it does not match' do
+      it 'does not match' do
         expect(subject).to be false
       end
     end

--- a/spec/openapi_contracts/doc/path_spec.rb
+++ b/spec/openapi_contracts/doc/path_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe OpenapiContracts::Doc::Path do
       'paths' => {
         '/messages/{id}' => {
           'parameters' => [id_param].compact
+        },
+        '/messages/{id}/{second_id}' => {
+          'parameters' => [id_param, second_id_param].compact
         }
       }
     }
@@ -14,6 +17,15 @@ RSpec.describe OpenapiContracts::Doc::Path do
   let(:id_param) do
     {
       'name'     => 'id',
+      'in'       => 'path',
+      'required' => true,
+      'schema'   => id_schema
+    }
+  end
+
+  let(:second_id_param) do
+    {
+      'name'     => 'second_id',
       'in'       => 'path',
       'required' => true,
       'schema'   => id_schema
@@ -44,6 +56,14 @@ RSpec.describe OpenapiContracts::Doc::Path do
         expect(param.name).to eq('id')
         expect(param).to be_in_path
       end
+    end
+  end
+
+  describe "#path_regexp" do
+    subject { doc.with_path("/messages/{id}/{second_id}").path_regexp.match("/messages/123/abc").captures }
+
+    it "matches both parameters" do
+      expect(subject).to eq(["123", "abc"])
     end
   end
 end

--- a/spec/openapi_contracts/doc/path_spec.rb
+++ b/spec/openapi_contracts/doc/path_spec.rb
@@ -60,10 +60,21 @@ RSpec.describe OpenapiContracts::Doc::Path do
   end
 
   describe '#path_regexp' do
-    subject { doc.with_path('/messages/{id}/{second_id}').path_regexp.match('/messages/123/abc').captures }
+    context "when there are two parameters" do
+      subject { doc.with_path('/messages/{id}/{second_id}').path_regexp.match('/messages/123/abc').captures }
 
-    it 'matches both parameters' do
-      expect(subject).to eq %w(123 abc)
+      it 'matches both parameters' do
+        expect(subject).to eq %w(123 abc)
+      end
+
+    end
+
+    context "when there is a trailing path" do
+      subject { doc.with_path('/messages/{id}').path_regexp.match?('/messages/123/trailing') }
+
+      it 'it does not match' do
+        expect(subject).to be false
+      end
     end
   end
 end

--- a/spec/openapi_contracts/doc/path_spec.rb
+++ b/spec/openapi_contracts/doc/path_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OpenapiContracts::Doc::Path do
   let(:schema) do
     {
       'paths' => {
-        '/messages/{id}' => {
+        '/messages/{id}'             => {
           'parameters' => [id_param].compact
         },
         '/messages/{id}/{second_id}' => {
@@ -59,11 +59,11 @@ RSpec.describe OpenapiContracts::Doc::Path do
     end
   end
 
-  describe "#path_regexp" do
-    subject { doc.with_path("/messages/{id}/{second_id}").path_regexp.match("/messages/123/abc").captures }
+  describe '#path_regexp' do
+    subject { doc.with_path('/messages/{id}/{second_id}').path_regexp.match('/messages/123/abc').captures }
 
-    it "matches both parameters" do
-      expect(subject).to eq(["123", "abc"])
+    it 'matches both parameters' do
+      expect(subject).to eq %w(123 abc)
     end
   end
 end


### PR DESCRIPTION
## Purpose

Parse paths with multiple parameters correctly

## Context

The original regular expression was too greedy and matched everything up to the last `}`. 

A path of `/messages/{id}/{second_id}` would capture `{id}/{second_id}` as a single group. This would confuse the `OperationRouter` which would fail `parameter_match?` 

