### PR TITLE
Fixes unknown method .to_json_pointer

### DIFF
--- a/lib/openapi_contracts/parser/transformers/pointer.rb
+++ b/lib/openapi_contracts/parser/transformers/pointer.rb
@@ -26,7 +26,7 @@ module OpenapiContracts::Parser::Transformers
         generate_absolute_pointer(pointer)
       elsif %r{^(?<relpath>[^#]+)(?:#/(?<pointer>.*))?} =~ target
         ptr = @parser.filenesting[@cwd.join(relpath)]
-        tgt = ptr.to_json_pointer
+        tgt = ptr
         tgt += "/#{pointer}" if pointer
         tgt
       else


### PR DESCRIPTION
Hello! Brilliant library, thanks for making it. 

I was using your main branch to avoid depdendecy conflict between this repo and openapi_first, and I was getting an error about this string (which is already a JSON Pointer) so figured I would try removing the method and it's worked.