### PR TITLE
Add support for validating text responses

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,6 +1,11 @@
+[language-server.solargraph]
+config.diagnostics=false
+config.formatting=false
+
 [[language]]
 name = "ruby"
-auto-format = true
+auto-format = false
 language-servers = [
-  { name = "rubocop" }
+  { name = "rubocop" },
+  { name="solargraph" }
 ]

--- a/lib/openapi_contracts/payload_parser.rb
+++ b/lib/openapi_contracts/payload_parser.rb
@@ -36,4 +36,5 @@ module OpenapiContracts
 
   PayloadParser.register(%r{(/|\+)json$}, ->(raw) { JSON(raw) })
   PayloadParser.register('application/x-www-form-urlencoded', ->(raw) { Rack::Utils.parse_nested_query(raw) })
+  PayloadParser.register(%r{^text/}, ->(raw) { raw })
 end

--- a/spec/fixtures/openapi/openapi.yaml
+++ b/spec/fixtures/openapi/openapi.yaml
@@ -54,6 +54,18 @@ paths:
           $ref: '#/components/responses/GenericError'
         '500':
           description: Server Error
+  /html:
+    get:
+      operationId: get_html
+      summary: HTML test
+      responses:
+        '200':
+          description: Empty string
+          content:
+            text/html:
+              schema:
+                type: string
+                maxLength: 1
   /numbers:
     get:
       operationId: numbers

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -176,4 +176,24 @@ RSpec.describe 'RSpec integration' do
       it { is_expected.to_not match_openapi_doc(doc, parameters: true) }
     end
   end
+
+  context 'when validating html responses' do
+    let(:method) { 'GET' }
+    let(:path) { '/html' }
+    let(:response_body) { ' ' }
+    let(:response_headers) do
+      {
+        'Content-Type' => 'text/html;charset=utf-8',
+        'X-Request-Id' => 'some-request-id'
+      }
+    end
+
+    it { is_expected.to match_openapi_doc(doc).with_http_status(:ok) }
+
+    context 'when the response is too long' do
+      let(:response_body) { 'too long' }
+
+      it { is_expected.to_not match_openapi_doc(doc).with_http_status(:ok) }
+    end
+  end
 end

--- a/spec/openapi_contracts/coverage_spec.rb
+++ b/spec/openapi_contracts/coverage_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe OpenapiContracts::Coverage do
     it 'can generate a report' do
       data = subject.as_json
       expect(data.dig('meta', 'operations', 'covered')).to eq(3)
-      expect(data.dig('meta', 'operations', 'total')).to eq(9)
+      expect(data.dig('meta', 'operations', 'total')).to eq(10)
       expect(data.dig('meta', 'responses', 'covered')).to eq(4)
-      expect(data.dig('meta', 'responses', 'total')).to eq(16)
+      expect(data.dig('meta', 'responses', 'total')).to eq(17)
     end
   end
 
@@ -58,9 +58,9 @@ RSpec.describe OpenapiContracts::Coverage do
     it 'can generate a report', :aggregate_failures do
       data = subject.as_json
       expect(data.dig('meta', 'operations', 'covered')).to eq(3)
-      expect(data.dig('meta', 'operations', 'total')).to eq(9)
+      expect(data.dig('meta', 'operations', 'total')).to eq(10)
       expect(data.dig('meta', 'responses', 'covered')).to eq(4)
-      expect(data.dig('meta', 'responses', 'total')).to eq(16)
+      expect(data.dig('meta', 'responses', 'total')).to eq(17)
     end
   end
 end

--- a/spec/openapi_contracts/doc_spec.rb
+++ b/spec/openapi_contracts/doc_spec.rb
@@ -29,6 +29,6 @@ RSpec.describe OpenapiContracts::Doc do
 
     it { is_expected.to all be_a(OpenapiContracts::Doc::Response) }
 
-    it { is_expected.to have_attributes(count: 16) }
+    it { is_expected.to have_attributes(count: 17) }
   end
 end


### PR DESCRIPTION
Support validating text (eg `text/html`) responses as plain strings.