### PR TITLE
add explicit header validation error messages

### DIFF
--- a/lib/openapi_contracts/validators/headers.rb
+++ b/lib/openapi_contracts/validators/headers.rb
@@ -18,9 +18,25 @@ module OpenapiContracts::Validators
 
         if value.blank?
           @errors << "Missing header #{header.name}" if header.required?
-        elsif !JSONSchemer.schema(header.schema).valid?(value)
-          @errors << "Header #{header.name} does not match"
+        else
+          schemer = JSONSchemer.schema(header.schema)
+          unless schemer.valid?(value)
+            validation_errors = schemer.validate(value).to_a
+            @errors << validation_error_message(header, value, validation_errors)
+          end
         end
+      end
+    end
+
+    def validation_error_message(header, value, error_array)
+      if error_array.empty?
+        "Header #{header.name} does not match schema"
+      else
+        error_array.map { |error|
+          error_message = "Header #{header.name} validation error: #{error['error']}"
+          truncated_value = value.to_s.truncate(100)
+          error_message + " (value: #{truncated_value})"
+        }.join("\n")
       end
     end
   end

--- a/spec/openapi_contracts/validators/headers_spec.rb
+++ b/spec/openapi_contracts/validators/headers_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe OpenapiContracts::Validators::Headers do
 
     it 'returns the error' do
       expect(subject.call).to eq [
-        'Header x-request-id does not match'
+        'Header x-request-id validation error: value at root is not a string (value: 1)'
       ]
     end
   end


### PR DESCRIPTION
I noticed that the header validation messages are basic and that was slowing me down when debugging an issue. JSONSchemer exposes more explicit validation error messages, so I took the opportunity to forward these messages to contract validation error output

See spec changes for example output