### PR TITLE
cleanup: remove deprecation warning (from rails 8.1)

### DIFF
--- a/lib/openapi_contracts.rb
+++ b/lib/openapi_contracts.rb
@@ -21,11 +21,9 @@ module OpenapiContracts
   autoload :PayloadParser,   'openapi_contracts/payload_parser'
   autoload :Validators,      'openapi_contracts/validators'
 
-  include ActiveSupport::Configurable
+  mattr_accessor :collect_coverage, default: false
 
   Env = Struct.new(:operation, :options, :request, :response, keyword_init: true)
-
-  config_accessor(:collect_coverage) { false }
 
   module_function
 


### PR DESCRIPTION
This commit removes the ActiveSupport::Configurable usage which is
being deprecated in Rails (it will be removed in rails 8.2).

The deprecation warning is being fired in my project using the gem :)
```
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.
```