### PR TITLE
Deserialize header values before validating

### DIFF
--- a/lib/openapi_contracts/validators/headers.rb
+++ b/lib/openapi_contracts/validators/headers.rb
@@ -19,6 +19,9 @@ module OpenapiContracts::Validators
         if value.blank?
           @errors << "Missing header #{header.name}" if header.required?
         else
+          # Header values arrive as strings; deserialize to the schema's type
+          # (per `style: simple`) before validating, as Doc::Parameter does.
+          value = OpenapiParameters::Converter.convert(value, header.schema)
           schemer = JSONSchemer.schema(header.schema)
           unless schemer.valid?(value)
             validation_errors = schemer.validate(value).to_a

--- a/spec/fixtures/openapi/openapi.yaml
+++ b/spec/fixtures/openapi/openapi.yaml
@@ -97,6 +97,10 @@ paths:
       responses:
         '200':
           description: Ok
+          headers:
+            x-rate-limit:
+              schema:
+                type: integer
           content:
             application/json:
               schema:

--- a/spec/openapi_contracts/validators/headers_spec.rb
+++ b/spec/openapi_contracts/validators/headers_spec.rb
@@ -46,4 +46,26 @@ RSpec.describe OpenapiContracts::Validators::Headers do
       ]
     end
   end
+
+  context 'with a non-string header type (style: simple)' do
+    include_context 'when using GET /pets'
+
+    context 'when the value parses to the declared type' do
+      before { response_headers['x-rate-limit'] = '300' }
+
+      it 'deserializes the value and has no errors' do
+        expect(subject.call).to be_empty
+      end
+    end
+
+    context 'when the value does not parse to the declared type' do
+      before { response_headers['x-rate-limit'] = 'not-a-number' }
+
+      it 'returns the error' do
+        expect(subject.call).to eq [
+          'Header x-rate-limit validation error: value at root is not an integer (value: not-a-number)'
+        ]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Header values are always transmitted as strings, but `Validators::Headers` validated the raw string against the header schema with no deserialization. Any header typed as `integer`, `number`, or `boolean` could therefore never validate — e.g. a `RateLimit-Limit: 300` response header failed against `{type: integer}` because "300" is a String.

Deserialize the value with `OpenapiParameters::Converter` before validating — the same converter `Doc::Parameter` already uses for query parameters — so a header's value is coerced to the type its schema declares (per `style: simple`). Values that can't be parsed are left unchanged and still fail validation.

Closes #115